### PR TITLE
raise informative error if a path cannot be parsed

### DIFF
--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -132,6 +132,13 @@ class _Finder(_FinderBase):
         out = list()
         for path in paths:
             parsed = self.parser.parse(path)
+
+            if parsed is None:
+                raise ValueError(
+                    f"Could not parse '{path}' with the pattern '{self.pattern}' - are"
+                    " there contradictory values?"
+                )
+
             out.append([path + self._suffix] + list(parsed.named.values()))
 
         keys = ["filename"] + list(parsed.named.keys())

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -445,3 +445,32 @@ def test_find_files_one_of_several(tmp_path, test_paths, find_kwargs):
 
     result = ff.find_files({"a": "XXX"}, **find_kwargs)
     pd.testing.assert_frame_equal(result.df, expected)
+
+
+def test_find_unparsable():
+
+    ff = FileFinder("{cat}", "{cat}", test_paths=["a/b"])
+
+    with pytest.raises(
+        ValueError, match="Could not parse 'a/b' with the pattern '{cat}/{cat}'"
+    ):
+        ff.find_files()
+
+    ff = FileFinder("", "{cat}_{cat}", test_paths=["a_b"])
+
+    with pytest.raises(
+        ValueError, match="Could not parse 'a_b' with the pattern '{cat}_{cat}'"
+    ):
+        ff.find_files()
+
+    ff = FileFinder("{cat}_{cat}", "", test_paths=["a_b/"])
+
+    with pytest.raises(
+        ValueError, match="Could not parse 'a_b/' with the pattern '{cat}_{cat}'"
+    ):
+        ff.find_files()
+
+    with pytest.raises(
+        ValueError, match="Could not parse 'a_b/' with the pattern '{cat}_{cat}/'"
+    ):
+        ff.find_paths()


### PR DESCRIPTION
E.g. if the same key matches to contradictory data:

```python
import parse
parse.parse("{key}_{key}", "{a}_{b}")
```