### PR TITLE
fix flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,11 +30,12 @@ install_requires =
 
 [flake8]
 ignore=
-    E203 # whitespace before ':' - doesn't work well with black
-    E402 # module level import not at top of file
-    E501 # line too long - let black worry about that
-    E731 # do not assign a lambda expression, use a def
-    W503 # line break before binary operator
+    # E203: whitespace before ':' - doesn't work well with black
+    # E402: module level import not at top of file
+    # E501: line too long - let black worry about that
+    # E731: do not assign a lambda expression, use a def
+    # W503: line break before binary operator
+    E203, E402, E501, E731, W503
 
 [isort]
 profile = black


### PR DESCRIPTION
flake8 version 6 no longer allows inline comments in the config file.