### PR TITLE
on_missing ignore to skip and foo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0 - unreleased
 
-- Change `on_missing` option in the `priority_filter` from "ignore" to "skip".
+- Change `on_missing` option in the `priority_filter` from "error" to "raise".
   ([#79](https://github.com/mathause/filefinder/pull/79))
 - Allow passing scalar numbers to `find_paths` and `find_files` ([#58](https://github.com/mathause/filefinder/issues/58)).
 - Show duplicates for non-unique queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## v0.3.0 - unreleased
 
+- Change on_missing option "ignore" to "skip". ([#79](https://github.com/mathause/filefinder/pull/79))
 - Allow passing scalar numbers to `find_paths` and `find_files` ([#58](https://github.com/mathause/filefinder/issues/58)).
-  - Show duplicates for non-unique queries
+- Show duplicates for non-unique queries
     ([#73](https://github.com/mathause/filefinder/pull/73))
 
 ## v0.2.0 - 23.05.2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v0.3.0 - unreleased
 
-- Change on_missing option "ignore" to "skip". ([#79](https://github.com/mathause/filefinder/pull/79))
+- Change `on_missing` option in the `priority_filter` from "ignore" to "skip".
+  ([#79](https://github.com/mathause/filefinder/pull/79))
 - Allow passing scalar numbers to `find_paths` and `find_files` ([#58](https://github.com/mathause/filefinder/issues/58)).
 - Show duplicates for non-unique queries
     ([#73](https://github.com/mathause/filefinder/pull/73))

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -28,7 +28,7 @@ def _wrap_filecontainer(func):
 
 
 @_wrap_filecontainer
-def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
+def priority_filter(obj, column, order, *, on_missing="raise", groupby=None):
     """filter a dataframe on for nonunique entries according to a priority list
 
     Parameters
@@ -39,7 +39,7 @@ def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
         The columt to apply the priority filter to.
     order : list of str
         The priority order.
-    on_missing : "error" | "warn" | "skip", default "error"
+    on_missing : "raise" | "warn" | "ignore", default "raise"
         Behaviour if none of the elements is found.
     groupy : None | list of str, default None
         Which columns to groupby over for the priority filter. Per default it uses all
@@ -50,16 +50,14 @@ def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
 
     """
 
-    if on_missing == "ignore":
+    if on_missing == "error":
         warnings.warn(
-            "on_missing value 'ignore' has been renamed to 'skip'", FutureWarning
+            "on_missing value 'error' has been renamed to 'raise'", FutureWarning
         )
-        on_missing = "skip"
+        on_missing = "raise"
 
-    if on_missing not in ["error", "warn", "skip"]:
-        raise ValueError(
-            f"Unknown value for 'on_missing': '{on_missing}'. Must be one of 'error', 'warn' or 'skip'."
-        )
+    if on_missing not in ["raise", "warn", "ignore"]:
+        raise ValueError(f"Unknown value for 'on_missing': '{on_missing}'. Must be one of 'raise', 'warn' or 'ignore'.")
 
     if column not in obj.columns:
         raise ValueError(f"column ('{column}') must be available in df")
@@ -117,7 +115,7 @@ def _prioritize(df, key, order, on_missing, multiindex):
         else:
             idx_string = one_.to_string()
 
-            if on_missing == "error":
+            if on_missing == "raise":
                 raise ValueError(
                     f"Did not find any element from the priority list for\n{idx_string}"
                 )
@@ -125,7 +123,7 @@ def _prioritize(df, key, order, on_missing, multiindex):
                 warnings.warn(
                     f"Did not find any element from the priority list for\n{idx_string}"
                 )
-            elif on_missing == "skip":
+            elif on_missing == "ignore":
                 pass
 
     df = pd.concat(out, axis=0)

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -51,7 +51,9 @@ def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
     """
 
     if on_missing == "ignore":
-        warnings.warn("on_missing value 'ignore' has been renamed to 'skip'", FutureWarning)
+        warnings.warn(
+            "on_missing value 'ignore' has been renamed to 'skip'", FutureWarning
+        )
         on_missing = "skip"
 
     if column not in obj.columns:

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -39,7 +39,7 @@ def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
         The columt to apply the priority filter to.
     order : list of str
         The priority order.
-    on_missing : "error" | "warn" | "ignore"
+    on_missing : "error" | "warn" | "skip", default "error"
         Behaviour if none of the elements is found.
     groupy : None | list of str, default None
         Which columns to groupby over for the priority filter. Per default it uses all
@@ -49,6 +49,10 @@ def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
 
 
     """
+
+    if on_missing == "ignore":
+        warnings.warn("on_missing value 'ignore' has been renamed to 'skip'", FutureWarning)
+        on_missing = "skip"
 
     if column not in obj.columns:
         raise ValueError(f"column ('{column}') must be available in df")
@@ -115,7 +119,7 @@ def _prioritize(df, key, order, on_missing, multiindex):
                 warnings.warn(
                     f"Did not find any element from the priority list for\n{idx_string}"
                 )
-            elif on_missing == "ignore":
+            elif on_missing == "skip":
                 pass
 
     df = pd.concat(out, axis=0)

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -57,7 +57,9 @@ def priority_filter(obj, column, order, *, on_missing="raise", groupby=None):
         on_missing = "raise"
 
     if on_missing not in ["raise", "warn", "ignore"]:
-        raise ValueError(f"Unknown value for 'on_missing': '{on_missing}'. Must be one of 'raise', 'warn' or 'ignore'.")
+        raise ValueError(
+            f"Unknown value for 'on_missing': '{on_missing}'. Must be one of 'raise', 'warn' or 'ignore'."
+        )
 
     if column not in obj.columns:
         raise ValueError(f"column ('{column}') must be available in df")

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -56,6 +56,9 @@ def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
         )
         on_missing = "skip"
 
+    if on_missing not in ["error", "warn", "skip"]:
+        raise ValueError("on_missing must be one of 'error', 'warn', 'skip'")
+
     if column not in obj.columns:
         raise ValueError(f"column ('{column}') must be available in df")
 
@@ -116,15 +119,12 @@ def _prioritize(df, key, order, on_missing, multiindex):
                 raise ValueError(
                     f"Did not find any element from the priority list for\n{idx_string}"
                 )
-
             elif on_missing == "warn":
                 warnings.warn(
                     f"Did not find any element from the priority list for\n{idx_string}"
                 )
             elif on_missing == "skip":
                 pass
-            else:
-                raise ValueError("on_missing must be one of 'error', 'warn', 'skip'")
 
     df = pd.concat(out, axis=0)
     df = df.reset_index(drop=True)

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -57,7 +57,7 @@ def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
         on_missing = "skip"
 
     if on_missing not in ["error", "warn", "skip"]:
-        raise ValueError("on_missing must be one of 'error', 'warn', 'skip'")
+        raise ValueError(f"Unknown value for 'on_missing': '{on_missing}'. Must be one of 'error', 'warn' or 'skip'.")
 
     if column not in obj.columns:
         raise ValueError(f"column ('{column}') must be available in df")

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -57,7 +57,9 @@ def priority_filter(obj, column, order, *, on_missing="error", groupby=None):
         on_missing = "skip"
 
     if on_missing not in ["error", "warn", "skip"]:
-        raise ValueError(f"Unknown value for 'on_missing': '{on_missing}'. Must be one of 'error', 'warn' or 'skip'.")
+        raise ValueError(
+            f"Unknown value for 'on_missing': '{on_missing}'. Must be one of 'error', 'warn' or 'skip'."
+        )
 
     if column not in obj.columns:
         raise ValueError(f"column ('{column}') must be available in df")

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -121,6 +121,8 @@ def _prioritize(df, key, order, on_missing, multiindex):
                 )
             elif on_missing == "skip":
                 pass
+            else:
+                raise ValueError(f"on_missing must be one of 'error', 'warn', 'skip'")
 
     df = pd.concat(out, axis=0)
     df = df.reset_index(drop=True)

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -124,7 +124,7 @@ def _prioritize(df, key, order, on_missing, multiindex):
             elif on_missing == "skip":
                 pass
             else:
-                raise ValueError(f"on_missing must be one of 'error', 'warn', 'skip'")
+                raise ValueError("on_missing must be one of 'error', 'warn', 'skip'")
 
     df = pd.concat(out, axis=0)
     df = df.reset_index(drop=True)

--- a/filefinder/tests/test_filters.py
+++ b/filefinder/tests/test_filters.py
@@ -59,21 +59,23 @@ def test_priority_filter_missing():
     ):
         result = priority_filter(df, "res", ["h", "d"], on_missing="warn")
 
-    with pytest.warns(
-        FutureWarning, match="on_missing value 'ignore' has been renamed to 'skip'"
+    with pytest.raises(
+        ValueError, match="Did not find any element from the priority list"
     ):
-        result = priority_filter(df, "res", ["h", "d"], on_missing="ignore")
+        with pytest.warns(
+            FutureWarning, match="on_missing value 'error' has been renamed to 'raise'"
+        ):
+            result = priority_filter(df, "res", ["h", "d"], on_missing="error")
 
     with pytest.raises(
-        ValueError,
-        match="Unknown value for 'on_missing': 'foo'. Must be one of 'error', 'warn' or 'skip'.",
+        ValueError, match="Unknown value for 'on_missing': 'foo'. Must be one of 'raise', 'warn' or 'ignore'."
     ):
         result = priority_filter(df, "res", ["h", "d"], on_missing="foo")
 
     pd.testing.assert_frame_equal(result, expected)
 
     with assert_no_warnings():
-        res = priority_filter(df, "res", ["h", "d"], on_missing="skip")
+        res = priority_filter(df, "res", ["h", "d"], on_missing="ignore")
 
     pd.testing.assert_frame_equal(res, expected)
 

--- a/filefinder/tests/test_filters.py
+++ b/filefinder/tests/test_filters.py
@@ -59,10 +59,20 @@ def test_priority_filter_missing():
     ):
         result = priority_filter(df, "res", ["h", "d"], on_missing="warn")
 
+    with pytest.warns(
+        FutureWarning, match="on_missing value 'ignore' has been renamed to 'skip'"
+    ):
+        result = priority_filter(df, "res", ["h", "d"], on_missing="ignore")
+
+    with pytest.raises(
+        ValueError, match="on_missing must be one of 'error', 'warn', 'skip'"
+    ):
+        result = priority_filter(df, "res", ["h", "d"], on_missing="foo")
+
     pd.testing.assert_frame_equal(result, expected)
 
     with assert_no_warnings():
-        res = priority_filter(df, "res", ["h", "d"], on_missing="ignore")
+        res = priority_filter(df, "res", ["h", "d"], on_missing="skip")
 
     pd.testing.assert_frame_equal(res, expected)
 

--- a/filefinder/tests/test_filters.py
+++ b/filefinder/tests/test_filters.py
@@ -68,7 +68,8 @@ def test_priority_filter_missing():
             result = priority_filter(df, "res", ["h", "d"], on_missing="error")
 
     with pytest.raises(
-        ValueError, match="Unknown value for 'on_missing': 'foo'. Must be one of 'raise', 'warn' or 'ignore'."
+        ValueError,
+        match="Unknown value for 'on_missing': 'foo'. Must be one of 'raise', 'warn' or 'ignore'.",
     ):
         result = priority_filter(df, "res", ["h", "d"], on_missing="foo")
 

--- a/filefinder/tests/test_filters.py
+++ b/filefinder/tests/test_filters.py
@@ -65,7 +65,8 @@ def test_priority_filter_missing():
         result = priority_filter(df, "res", ["h", "d"], on_missing="ignore")
 
     with pytest.raises(
-        ValueError, match="Unknown value for 'on_missing': 'foo'. Must be one of 'error', 'warn' or 'skip'."
+        ValueError,
+        match="Unknown value for 'on_missing': 'foo'. Must be one of 'error', 'warn' or 'skip'.",
     ):
         result = priority_filter(df, "res", ["h", "d"], on_missing="foo")
 

--- a/filefinder/tests/test_filters.py
+++ b/filefinder/tests/test_filters.py
@@ -65,7 +65,7 @@ def test_priority_filter_missing():
         result = priority_filter(df, "res", ["h", "d"], on_missing="ignore")
 
     with pytest.raises(
-        ValueError, match="on_missing must be one of 'error', 'warn', 'skip'"
+        ValueError, match="Unknown value for 'on_missing': 'foo'. Must be one of 'error', 'warn' or 'skip'."
     ):
         result = priority_filter(df, "res", ["h", "d"], on_missing="foo")
 


### PR DESCRIPTION
Closes #77 
Change option "ignore" to "skip" in on_missing to be consistent with on_parse_error (see #75).
Implement behavior if on_missing is none of the implemented options.