### PR TITLE
fix typos (using codespell)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ New release that allows to specify a format spec which allows parsing more compl
 - Add tests for the cmip functionality and fix issue with `filefinder.cmip.ensure_unique_grid`
   ([#35](https://github.com/mathause/filefinder/pull/35)).
 - Removed support for python 3.6.
-- Explicitely test python 3.11.
+- Explicitly test python 3.11.
 
 ## v0.1.0 - 05.08.2022
 
-- First version released based on the code developped for my IPCC AR6 analyses and including some additions (e.g. `priority_filter`, prefering `kwargs` over keys passed via a dictionary, more complete tests).
+- First version released based on the code developed for my IPCC AR6 analyses and including some additions (e.g. `priority_filter`, preferring `kwargs` over keys passed via a dictionary, more complete tests).

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -438,7 +438,7 @@ class FileContainer:
             return ret
 
     def combine_by_key(self, keys=None, sep="."):
-        """combine colums"""
+        """combine columns"""
 
         if keys is None:
             keys = list(self.df.columns.drop("filename"))


### PR DESCRIPTION

```bash
codespell --skip=".git,devel,_build" --ignore-words-list "varn" . --write-changes -i 3
```