### PR TITLE
raise on reserved placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.0 - unreleased
+
+- `FileFinder` now raises an error if an invalid `"{placeholder}"` is used
+   ([#99](https://github.com/mathause/filefinder/pull/99)).
+
 ## v0.3.0 - 27.03.2024
 
 New release that adds handling for parsing errors. It also drops python 3.7 and 3.8 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.4.0 - unreleased
 
+- The `FileFinder.find_files` arguments `on_parse_error` and `_allow_empty` can no
+  longer be passed by position ([#99](https://github.com/mathause/filefinder/pull/99)).
 - `FileFinder` now raises an error if an invalid `"{placeholder}"` is used
    ([#99](https://github.com/mathause/filefinder/pull/99)).
 

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -10,7 +10,12 @@ import numpy as np
 import pandas as pd
 import parse
 
-from .utils import _find_keys, natural_keys, product_dict, update_dict_with_kwargs
+from filefinder.utils import (
+    _find_keys,
+    natural_keys,
+    product_dict,
+    update_dict_with_kwargs,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,12 +26,22 @@ file_pattern: '{file_pattern}'
 keys: {repr_keys}
 """
 
+_RESERVED_PLACEHOLDERS = {"keys", "on_parse_error", "_allow_empty"}
+
+
+def _assert_valid_keys(keys):
+
+    for key in _RESERVED_PLACEHOLDERS:
+        if key in keys:
+            raise ValueError(f"'{key}' is not a valid placeholder")
+
 
 class _FinderBase:
     def __init__(self, pattern, suffix=""):
 
         self.pattern = pattern
         self.keys = _find_keys(pattern)
+        _assert_valid_keys(self.keys)
         self.parser = parse.compile(self.pattern)
         self._suffix = suffix
 
@@ -384,7 +399,7 @@ class FileFinder:
         )
 
     def find_files(
-        self, keys=None, on_parse_error="raise", _allow_empty=False, **keys_kwargs
+        self, keys=None, *, on_parse_error="raise", _allow_empty=False, **keys_kwargs
     ):
         """find files in the file system using the file pattern
 

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -10,12 +10,7 @@ import numpy as np
 import pandas as pd
 import parse
 
-from filefinder.utils import (
-    _find_keys,
-    natural_keys,
-    product_dict,
-    update_dict_with_kwargs,
-)
+from .utils import _find_keys, natural_keys, product_dict, update_dict_with_kwargs
 
 logger = logging.getLogger(__name__)
 

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -45,6 +45,16 @@ def test_paths(request, tmp_path):
     return paths
 
 
+@pytest.mark.parametrize("placeholder", ("keys", "on_parse_error", "_allow_empty"))
+def test_pattern_invalid_placeholder(placeholder):
+
+    with pytest.raises(ValueError, match=f"'{placeholder}' is not a valid placeholder"):
+        FileFinder("", f"{{{placeholder}}}")
+
+    with pytest.raises(ValueError, match=f"'{placeholder}' is not a valid placeholder"):
+        FileFinder(f"{{{placeholder}}}", "")
+
+
 def test_pattern_property():
 
     path_pattern = "path_pattern/"


### PR DESCRIPTION

- closes #97

`"keys"`, `"on_parse_error"`, and `"_allow_empty"` can (currently) not be used as "`{placeholders}`" because they are used as (keyword) arguments. This PR adds a check to raise an error if they are used.