### PR TITLE
rename `_allow_empty` to `allow_empty`

### DIFF
--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -33,9 +33,6 @@ def _assert_valid_keys(keys):
 
 def _rename_allow_empty(allow_empty, **kwargs):
 
-    print(allow_empty)
-    print(kwargs)
-
     _allow_empty = kwargs.get("_allow_empty")
 
     if allow_empty is not None and _allow_empty is not None:

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -82,9 +82,8 @@ def test_allow_empty_rename(method):
         with pytest.raises(ValueError):
             meth(_allow_empty=False)
 
-    with pytest.warns(FutureWarning):
-        with pytest.raises(ValueError):
-            meth(allow_empty=False)
+    with pytest.raises(ValueError):
+        meth(allow_empty=False)
 
 
 def test_pattern_property():


### PR DESCRIPTION
This is probably overkill but with #99 we just forbid this placeholder (not that it is a very likely name in the first place).

Alternatively we could do 

```
on_empty : "raise" | "warn" | "ignore", default: "raise"
```

(but ignore is not a good name, better would be "return" but then we break the symmetry which is also not nice, aahrg)