### PR TITLE
GHA: use codecov token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
         --junitxml=test-results/${{ runner.os }}-${{ matrix.python-version }}.xml
     - name: Upload code coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
           file: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
also in this repo... (c.f. MESMER-group/mesmer#507)