### PR TITLE
error for unnamed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added two methods to find _exactly_ one file or path (and raise an error otherwise):
   `FileFinder.find_single_file` and `FileFinder.find_single_path`
   ([#101](https://github.com/mathause/filefinder/pull/101)).
+- Raise an error if an unnamed placeholder (e.g., `"{}"`) is passed
+  ([#110](https://github.com/mathause/filefinder/pull/110))
 - The `FileFinder.find_files` arguments `on_parse_error` and `_allow_empty` can no
   longer be passed by position ([#99](https://github.com/mathause/filefinder/pull/99)).
 - `FileFinder` now raises an error if an invalid `"{placeholder}"` is used

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -38,6 +38,14 @@ class _FinderBase:
         self.keys = _find_keys(pattern)
         _assert_valid_keys(self.keys)
         self.parser = parse.compile(self.pattern)
+
+        if self.parser.fixed_fields:
+            msg = (
+                "Only named fields are currently allowed: avoid empty braces and"
+                " leading underscores."
+            )
+            raise ValueError(msg)
+
         self._suffix = suffix
 
         # replace the fmt spec - add the capture group again

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -55,6 +55,16 @@ def test_pattern_invalid_placeholder(placeholder):
         FileFinder(f"{{{placeholder}}}", "")
 
 
+@pytest.mark.parametrize("pattern", ("{}", "{_fixed}"))
+def test_only_named_fields(pattern):
+
+    with pytest.raises(ValueError, match="Only named fields are currently allowed"):
+        FileFinder("", pattern)
+
+    with pytest.raises(ValueError, match="Only named fields are currently allowed"):
+        FileFinder(pattern, "")
+
+
 def test_pattern_property():
 
     path_pattern = "path_pattern/"


### PR DESCRIPTION
Parsing names with unnamed fields does not work at the moment. We could also fix this but raise an error for now.