### PR TITLE
`FileContainer`: "filename" to "path" and `Index`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,8 @@
 
 - Changes to `FileContainer`:
 
-  - Renamed the `"filename"` column of `FileContainer` to `"path"` and made it a
-    `pd.Index`, thus removing this column from the underlying `DataFrame`
-    ([#113](https://github.com/mathause/filefinder/pull/113)).
+  - Renamed the `"filename"` column to `"path"` and made it a `pd.Index`, thus removing
+    this column from the underlying `DataFrame` ([#113](https://github.com/mathause/filefinder/pull/113)).
 
 - Explicitly test on python 3.13 ([#103](https://github.com/mathause/filefinder/pull/103)).
 - Drop support for python 3.9 ([#102](https://github.com/mathause/filefinder/pull/102)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   longer be passed by position ([#99](https://github.com/mathause/filefinder/pull/99)).
 - `FileFinder` now raises an error if an invalid `"{placeholder}"` is used
    ([#99](https://github.com/mathause/filefinder/pull/99)).
+
+- Changes to `FileContainer`:
+
+  - Renamed the `"filename"` column of `FileContainer` to `"path"` and made it a
+    `pd.Index`, thus removing this column from the underlying `DataFrame`
+    ([#113](https://github.com/mathause/filefinder/pull/113)).
+
 - Explicitly test on python 3.13 ([#103](https://github.com/mathause/filefinder/pull/103)).
 - Drop support for python 3.9 ([#102](https://github.com/mathause/filefinder/pull/102)).
 

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -557,7 +557,7 @@ class FileContainer:
     def __iter__(self):
 
         for index, element in self.df.iterrows():
-            yield element["filename"], element.drop("filename").to_dict()
+            yield index, element.to_dict()
 
     def __getitem__(self, key):
 

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -199,7 +199,7 @@ class _Finder(_FinderBase):
 
     def _parse_paths(self, paths, on_parse_error):
 
-        out = list()
+        valid_paths, out = list(), list()
         for path in paths:
             parsed = self.parser.parse(path)
 
@@ -217,11 +217,11 @@ class _Finder(_FinderBase):
                 elif on_parse_error == "ignore":
                     pass
             else:
-                out.append([path + self._suffix] + list(parsed.named.values()))
+                valid_paths.append(path)
+                out.append(list(parsed.named.values()))
 
-        keys = ["filename"] + list(self.keys)
-
-        df = pd.DataFrame(out, columns=keys)
+        index = pd.Index(valid_paths, name="path") + self._suffix
+        df = pd.DataFrame(out, columns=self.keys, index=index)
         return df
 
 
@@ -550,7 +550,7 @@ class FileFinder:
 class FileContainer:
     """docstring for FileContainer"""
 
-    def __init__(self, df):
+    def __init__(self, df: pd.DataFrame):
 
         self.df = df
 
@@ -565,7 +565,7 @@ class FileContainer:
             # use iloc -> there can be more than one element with index 0
             element = self.df.iloc[key]
 
-            return element["filename"], element.drop("filename").to_dict()
+            return element.name, element.to_dict()
         # assume slice or [1]
         else:
             ret = copy.copy(self)
@@ -576,7 +576,7 @@ class FileContainer:
         """combine columns"""
 
         if keys is None:
-            keys = list(self.df.columns.drop("filename"))
+            keys = list(self.df.columns)
 
         return self.df[list(keys)].apply(lambda x: sep.join(x.map(str)), axis=1)
 
@@ -588,7 +588,9 @@ class FileContainer:
 
     def _get_subset(self, **query):
         if not query:
-            return pd.DataFrame(columns=self.df.columns)
+            return pd.DataFrame(
+                [], columns=self.df.columns, index=pd.Index([], name="path")
+            )
         condition = np.ones(len(self.df), dtype=bool)
         for key, val in query.items():
             if isinstance(val, list):

--- a/filefinder/filters.py
+++ b/filefinder/filters.py
@@ -126,6 +126,5 @@ def _prioritize(df, key, order, on_missing, multiindex):
                 pass
 
     df = pd.concat(out, axis=0)
-    df = df.reset_index(drop=True)
 
     return df

--- a/filefinder/tests/test_cmip.py
+++ b/filefinder/tests/test_cmip.py
@@ -16,8 +16,8 @@ def test_parse_ens_cmip5():
             ("file4", "r1i2p1"),
             ("file5", "r1i1p2"),
         ],
-        columns=("filename", "ens"),
-    )
+        columns=("path", "ens"),
+    ).set_index("path")
 
     fc = FileContainer(df)
 
@@ -29,8 +29,8 @@ def test_parse_ens_cmip5():
             ("file4", "r1i2p1", "1", "2", "1"),
             ("file5", "r1i1p2", "1", "1", "2"),
         ],
-        columns=("filename", "ens", "r", "i", "p"),
-    )
+        columns=("path", "ens", "r", "i", "p"),
+    ).set_index("path")
 
     result = parse_ens(fc)
     assert isinstance(result, FileContainer)
@@ -50,8 +50,8 @@ def test_parse_ens_cmip6():
             ("file4", "r1i2p1f1"),
             ("file5", "r1i1p2f1"),
         ],
-        columns=("filename", "ens"),
-    )
+        columns=("path", "ens"),
+    ).set_index("path")
 
     fc = FileContainer(df)
 
@@ -63,8 +63,8 @@ def test_parse_ens_cmip6():
             ("file4", "r1i2p1f1", "1", "2", "1", "1"),
             ("file5", "r1i1p2f1", "1", "1", "2", "1"),
         ],
-        columns=("filename", "ens", "r", "i", "p", "f"),
-    )
+        columns=("path", "ens", "r", "i", "p", "f"),
+    ).set_index("path")
 
     result = parse_ens(fc)
     assert isinstance(result, FileContainer)
@@ -73,7 +73,7 @@ def test_parse_ens_cmip6():
 
 
 def test_create_ensnumber():
-    columns = ("filename", "model", "exp", "table", "varn", "ens")
+    columns = ("path", "model", "exp", "table", "varn", "ens")
 
     common = ("exp", "table", "varn")
 
@@ -88,12 +88,12 @@ def test_create_ensnumber():
     df = pd.DataFrame.from_records(
         records,
         columns=columns,
-    )
+    ).set_index("path")
 
     expected_df = pd.DataFrame.from_records(
         records,
         columns=columns,
-    )
+    ).set_index("path")
     expected_df["ensnumber"] = (0, 1, 2, 0, 1)
 
     fc = FileContainer(df)
@@ -106,7 +106,7 @@ def test_create_ensnumber():
 
 def test_ensure_unique_grid():
 
-    columns = ("model", "exp", "table", "varn", "ens", "grid")
+    columns = ("path", "model", "exp", "table", "varn", "ens", "grid")
 
     # VALID_GRIDS = ("gn", "gr", "gr1", "gm")
 
@@ -114,22 +114,22 @@ def test_ensure_unique_grid():
 
     df = pd.DataFrame.from_records(
         [
-            ("CESM2", *common, "gr"),
-            ("CESM2", *common, "gn"),
-            ("CESM2", *common, "gm"),
-            ("UKESM", *common, "gr"),
-            ("UKESM", *common, "gr1"),
+            ("CESM2_gr", "CESM2", *common, "gr"),
+            ("CESM2_gn", "CESM2", *common, "gn"),
+            ("CESM2_gm", "CESM2", *common, "gm"),
+            ("UKESM_gr", "UKESM", *common, "gr"),
+            ("UKESM_gr1", "UKESM", *common, "gr1"),
         ],
         columns=columns,
-    )
+    ).set_index("path")
 
     expected = pd.DataFrame.from_records(
         [
-            ("CESM2", *common, "gn"),
-            ("UKESM", *common, "gr"),
+            ("CESM2_gn", "CESM2", *common, "gn"),
+            ("UKESM_gr", "UKESM", *common, "gr"),
         ],
         columns=columns,
-    )
+    ).set_index("path")
 
     result = ensure_unique_grid(df)
 

--- a/filefinder/tests/test_filecontainer.py
+++ b/filefinder/tests/test_filecontainer.py
@@ -1,0 +1,90 @@
+import pandas as pd
+import pytest
+
+from filefinder import FileContainer
+
+from . import assert_empty_filecontainer
+
+
+@pytest.fixture
+def example_df():
+
+    df = pd.DataFrame.from_records(
+        [
+            ("file0", "a", "d", "r"),
+            ("file1", "a", "h", "r"),
+            ("file2", "b", "h", "r"),
+            ("file3", "b", "d", "r"),
+            ("file4", "c", "d", "r"),
+        ],
+        columns=("path", "model", "scen", "res"),
+    ).set_index("path")
+
+    return df
+
+
+@pytest.fixture
+def example_fc(example_df):
+
+    return FileContainer(example_df)
+
+
+def test_empty_filecontainer():
+
+    df = pd.DataFrame([], columns=["cat"], index=pd.Index([], name="path"))
+
+    fc = FileContainer(df)
+
+    assert fc.df is df
+    assert len(fc) == 0
+
+
+def test_filecontainer(example_df, example_fc):
+
+    assert example_fc.df is example_df
+    assert len(example_fc) == 5
+
+
+def test_filecontainer_search(example_df, example_fc):
+
+    assert_empty_filecontainer(example_fc.search())
+    assert_empty_filecontainer(example_fc.search(model="d"))
+
+    result = example_fc.search(model="a")
+    expected = example_df.iloc[[0, 1]]
+    pd.testing.assert_frame_equal(result.df, expected)
+
+    result = example_fc.search(model=["a", "c"])
+    expected = example_df.iloc[[0, 1, 4]]
+    pd.testing.assert_frame_equal(result.df, expected)
+
+    result = example_fc.search(model="a", scen="h")
+    expected = example_df.iloc[[1]]
+    pd.testing.assert_frame_equal(result.df, expected)
+
+    result = example_fc.search(model=["a", "b"], scen="d")
+    expected = example_df.iloc[[0, 3]]
+    pd.testing.assert_frame_equal(result.df, expected)
+
+
+def test_fc_combine_by_keys(example_fc):
+
+    result = example_fc[[0]].combine_by_key()
+
+    # create one manually
+    expected = pd.Series(["a.d.r"], index=pd.Index(["file0"], name="path"))
+    pd.testing.assert_series_equal(result, expected)
+
+    result = example_fc.combine_by_key()
+    expected = map(".".join, example_fc.df.values)
+    expected = pd.Series(expected, index=example_fc.df.index)
+
+    # different sep
+    result = example_fc.combine_by_key(sep="|")
+    expected = map("|".join, example_fc.df.values)
+    expected = pd.Series(expected, index=example_fc.df.index)
+
+    # not all columns
+    result = example_fc.combine_by_key(keys=("model", "res"))
+    expected = map(".".join, example_fc.df[["model", "res"]].values)
+    expected = pd.Series(expected, index=example_fc.df.index)

--- a/filefinder/tests/test_filecontainer.py
+++ b/filefinder/tests/test_filecontainer.py
@@ -3,9 +3,6 @@ import pytest
 
 from filefinder import FileContainer
 
-from . import assert_empty_filecontainer
-
-
 @pytest.fixture
 def example_df():
 
@@ -47,8 +44,8 @@ def test_filecontainer(example_df, example_fc):
 
 def test_filecontainer_search(example_df, example_fc):
 
-    assert_empty_filecontainer(example_fc.search())
-    assert_empty_filecontainer(example_fc.search(model="d"))
+    assert len(example_fc.search()) == 0
+    assert len(example_fc.search(model="d")) == 0
 
     result = example_fc.search(model="a")
     expected = example_df.iloc[[0, 1]]

--- a/filefinder/tests/test_filecontainer.py
+++ b/filefinder/tests/test_filecontainer.py
@@ -3,6 +3,7 @@ import pytest
 
 from filefinder import FileContainer
 
+
 @pytest.fixture
 def example_df():
 
@@ -35,11 +36,26 @@ def test_empty_filecontainer():
     assert fc.df is df
     assert len(fc) == 0
 
+    with pytest.raises(StopIteration):
+        next(iter(fc))
+
 
 def test_filecontainer(example_df, example_fc):
 
     assert example_fc.df is example_df
     assert len(example_fc) == 5
+
+
+def test_fc_iter(example_df, example_fc):
+
+    # test one manually
+    path, meta = next(iter(example_fc))
+    assert path == "file0"
+    assert meta == {"model": "a", "scen": "d", "res": "r"}
+
+    result = list(example_fc)
+    expected = list(zip(example_df.index.to_list(), example_df.to_dict("records")))
+    assert result == expected
 
 
 def test_filecontainer_search(example_df, example_fc):

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -227,8 +227,8 @@ def test_find_paths_simple(tmp_path, test_paths):
         path_pattern=path_pattern, file_pattern=file_pattern, test_paths=test_paths
     )
 
-    expected = {"filename": {0: str(tmp_path / "a1/foo/*")}, "a": {0: "foo"}}
-    expected = pd.DataFrame.from_dict(expected)
+    expected = {"path": {0: str(tmp_path / "a1/foo/*")}, "a": {0: "foo"}}
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_paths(a="foo")
     pd.testing.assert_frame_equal(result.df, expected)
@@ -251,11 +251,11 @@ def test_find_paths_wildcard(tmp_path, test_paths, find_kwargs):
     )
 
     expected = {
-        "filename": {0: str(tmp_path / "a1/foo/*"), 1: str(tmp_path / "a2/foo/*")},
+        "path": {0: str(tmp_path / "a1/foo/*"), 1: str(tmp_path / "a2/foo/*")},
         "a": {0: "a1", 1: "a2"},
         "b": {0: "foo", 1: "foo"},
     }
-    expected = pd.DataFrame.from_dict(expected)
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_paths(**find_kwargs)
     pd.testing.assert_frame_equal(result.df, expected)
@@ -281,11 +281,11 @@ def test_find_paths_several(tmp_path, test_paths, find_kwargs):
     )
 
     expected = {
-        "filename": {0: str(tmp_path / "a1/foo/*"), 1: str(tmp_path / "a2/foo/*")},
+        "path": {0: str(tmp_path / "a1/foo/*"), 1: str(tmp_path / "a2/foo/*")},
         "a": {0: "a1", 1: "a2"},
         "b": {0: "foo", 1: "foo"},
     }
-    expected = pd.DataFrame.from_dict(expected)
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_paths(**find_kwargs)
     pd.testing.assert_frame_equal(result.df, expected)
@@ -311,11 +311,11 @@ def test_find_paths_one_of_several(tmp_path, test_paths, find_kwargs):
     )
 
     expected = {
-        "filename": {0: str(tmp_path / "a1/foo/*")},
+        "path": {0: str(tmp_path / "a1/foo/*")},
         "a": {0: "a1"},
         "b": {0: "foo"},
     }
-    expected = pd.DataFrame.from_dict(expected)
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_paths(**find_kwargs)
     pd.testing.assert_frame_equal(result.df, expected)
@@ -344,8 +344,8 @@ def test_find_single_path(tmp_path, test_paths):
     with pytest.raises(ValueError, match="Found no files matching criteria"):
         ff.find_single_path(a="a3")
 
-    expected = {"filename": {0: str(tmp_path / "a1/foo/*")}, "a": {0: "a1"}}
-    expected = pd.DataFrame.from_dict(expected)
+    expected = {"path": {0: str(tmp_path / "a1/foo/*")}, "a": {0: "a1"}}
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_single_path(a="a1")
     pd.testing.assert_frame_equal(result.df, expected)
@@ -388,8 +388,8 @@ def test_find_file_simple(tmp_path, test_paths):
         path_pattern=path_pattern, file_pattern=file_pattern, test_paths=test_paths
     )
 
-    expected = {"filename": {0: str(tmp_path / "a1/foo/file")}, "a": {0: "foo"}}
-    expected = pd.DataFrame.from_dict(expected)
+    expected = {"path": {0: str(tmp_path / "a1/foo/file")}, "a": {0: "foo"}}
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_files(a="foo")
     pd.testing.assert_frame_equal(result.df, expected)
@@ -412,14 +412,14 @@ def test_find_files_wildcard(tmp_path, test_paths, find_kwargs):
     )
 
     expected = {
-        "filename": {
+        "path": {
             0: str(tmp_path / "a1/foo/file"),
             1: str(tmp_path / "a2/foo/file"),
         },
         "a": {0: "a1", 1: "a2"},
         "b": {0: "file", 1: "file"},
     }
-    expected = pd.DataFrame.from_dict(expected)
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_files(**find_kwargs)
     pd.testing.assert_frame_equal(result.df, expected)
@@ -445,14 +445,14 @@ def test_find_files_several(tmp_path, test_paths, find_kwargs):
     )
 
     expected = {
-        "filename": {
+        "path": {
             0: str(tmp_path / "a1/foo/file"),
             1: str(tmp_path / "a2/foo/file"),
         },
         "a": {0: "a1", 1: "a2"},
         "b": {0: "file", 1: "file"},
     }
-    expected = pd.DataFrame.from_dict(expected)
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_files(**find_kwargs)
     pd.testing.assert_frame_equal(result.df, expected)
@@ -478,11 +478,11 @@ def test_find_files_one_of_several(tmp_path, test_paths, find_kwargs):
     )
 
     expected = {
-        "filename": {0: str(tmp_path / "a1/foo/file")},
+        "path": {0: str(tmp_path / "a1/foo/file")},
         "a": {0: "a1"},
         "b": {0: "file"},
     }
-    expected = pd.DataFrame.from_dict(expected)
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_files(**find_kwargs)
     pd.testing.assert_frame_equal(result.df, expected)
@@ -511,8 +511,8 @@ def test_find_single_file(tmp_path, test_paths):
     with pytest.raises(ValueError, match="Found no files matching criteria"):
         ff.find_single_file(a="a3")
 
-    expected = {"filename": {0: str(tmp_path / "a1/foo/file")}, "a": {0: "a1"}}
-    expected = pd.DataFrame.from_dict(expected)
+    expected = {"path": {0: str(tmp_path / "a1/foo/file")}, "a": {0: "a1"}}
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_single_file(a="a1")
     pd.testing.assert_frame_equal(result.df, expected)
@@ -527,8 +527,8 @@ def test_find_paths_scalar_number():
         path_pattern="{path}", file_pattern="{file}", test_paths=["1/1", "2/2"]
     )
 
-    expected = {"filename": {0: "1/*"}, "path": {0: "1"}}
-    expected = pd.DataFrame.from_dict(expected)
+    index = pd.Index(["1/*"], name="path")
+    expected = pd.DataFrame(["1"], columns=["path"], index=index)
     result = ff.find_paths(path=1)
     pd.testing.assert_frame_equal(result.df, expected)
 
@@ -539,8 +539,8 @@ def test_find_files_scalar_number():
         path_pattern="{path}", file_pattern="{file}", test_paths=["1/1", "2/2"]
     )
 
-    expected = {"filename": {0: "1/1"}, "path": {0: "1"}, "file": {0: "1"}}
-    expected = pd.DataFrame.from_dict(expected)
+    index = pd.Index(["1/1"], name="path")
+    expected = pd.DataFrame([["1", "1"]], columns=["path", "file"], index=index)
     result = ff.find_files(file=1)
     pd.testing.assert_frame_equal(result.df, expected)
 
@@ -554,7 +554,7 @@ def test_find_unparsable():
     ):
         ff.find_files()
 
-    expected = pd.DataFrame(list(), columns=["filename", "cat"])
+    expected = pd.DataFrame([], columns=["cat"], index=pd.Index([], name="path"))
 
     with pytest.warns(match="Could not parse 'a/b' with the pattern '{cat}/{cat}'"):
         result = ff.find_files(on_parse_error="warn")
@@ -564,8 +564,8 @@ def test_find_unparsable():
     pd.testing.assert_frame_equal(result.df, expected)
 
     ff = FileFinder("{cat}", "{cat}", test_paths=["a/b", "a/a"])
-    expected = {"filename": {0: "a/a"}, "cat": {0: "a"}}
-    expected = pd.DataFrame.from_dict(expected)
+    expected = {"path": {0: "a/a"}, "cat": {0: "a"}}
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
     result = ff.find_files(on_parse_error="ignore")
     pd.testing.assert_frame_equal(result.df, expected)
 

--- a/filefinder/tests/test_filefinder_fmt.py
+++ b/filefinder/tests/test_filefinder_fmt.py
@@ -111,13 +111,13 @@ def test_find_paths_fmt():
     )
 
     expected = {
-        "filename": {0: "a1/a1_abc", 1: "ab200/ab200_aicdef"},
+        "path": {0: "a1/a1_abc", 1: "ab200/ab200_aicdef"},
         "letters": {0: "a", 1: "ab"},
         "num": {0: 1, 1: 200},
         "beg": {0: "ab", 1: "ai"},
         "end": {0: "c", 1: "cdef"},
     }
-    expected = pd.DataFrame.from_dict(expected)
+    expected = pd.DataFrame.from_dict(expected).set_index("path")
 
     result = ff.find_files()
     pd.testing.assert_frame_equal(result.df, expected)

--- a/filefinder/tests/test_filters.py
+++ b/filefinder/tests/test_filters.py
@@ -31,7 +31,7 @@ def test_priority_filter_simple():
     )
 
     expected = pd.DataFrame.from_records(
-        [("a", "h"), ("b", "h"), ("c", "d")], columns=("model", "res")
+        [("a", "h"), ("b", "h"), ("c", "d")], columns=("model", "res"), index=(1, 2, 4)
     )
 
     result = priority_filter(df, "res", ["h", "d"])
@@ -46,7 +46,7 @@ def test_priority_filter_missing():
     )
 
     expected = pd.DataFrame.from_records(
-        [("a", "h"), ("b", "d")], columns=("model", "res")
+        [("a", "h"), ("b", "d")], columns=("model", "res"), index=(1, 2)
     )
 
     with pytest.raises(
@@ -96,10 +96,7 @@ def test_priority_filter_multi():
         columns=("model", "number", "res"),
     )
 
-    expected = pd.DataFrame.from_records(
-        [("a", 1, "h"), ("a", 2, "d"), ("b", 1, "h")],
-        columns=("model", "number", "res"),
-    )
+    expected = df.iloc[[2, 1, 3]]
 
     result = priority_filter(df, "res", ["h", "d"])
 
@@ -122,6 +119,8 @@ def test_priority_filter_groupby():
         [("a", 2, "h"), ("b", 1, "h")], columns=("model", "number", "res")
     )
     result = priority_filter(df, "res", ["h", "d"], groupby=["model"])
+
+    result = result.reset_index(drop=True)
     pd.testing.assert_frame_equal(result, expected)
 
 
@@ -135,13 +134,13 @@ def test_priority_filter_filename():
             ("file4", "b", "d"),
             ("file5", "c", "d"),
         ],
-        columns=("filename", "model", "res"),
-    )
+        columns=("path", "model", "res"),
+    ).set_index("path")
 
     expected = pd.DataFrame.from_records(
         [("file2", "a", "h"), ("file3", "b", "h"), ("file5", "c", "d")],
-        columns=("filename", "model", "res"),
-    )
+        columns=("path", "model", "res"),
+    ).set_index("path")
 
     result = priority_filter(df, "res", ["h", "d"])
 
@@ -158,15 +157,15 @@ def test_priority_filter_filecontainer_simple():
             ("file4", "b", "d"),
             ("file5", "c", "d"),
         ],
-        columns=("filename", "model", "res"),
-    )
+        columns=("path", "model", "res"),
+    ).set_index("path")
 
     fc = FileContainer(df)
 
     expected = pd.DataFrame.from_records(
         [("file2", "a", "h"), ("file3", "b", "h"), ("file5", "c", "d")],
-        columns=("filename", "model", "res"),
-    )
+        columns=("path", "model", "res"),
+    ).set_index("path")
 
     result = priority_filter(fc, "res", ["h", "d"])
 


### PR DESCRIPTION

- towards #111 points 4. and 5.

Renames the `"filename"` column of `FileContainer` to `"path"` and makes it a `pd.Index`. The biggest work was actually to fix the tests. It also adds some new tests for the `FileContainer`.