### PR TITLE
return empty `FileContainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   longer be passed by position ([#99](https://github.com/mathause/filefinder/pull/99)).
 - `FileFinder` now raises an error if an invalid `"{placeholder}"` is used
    ([#99](https://github.com/mathause/filefinder/pull/99)).
+- An empty `FileContainer` is returned instead of an empty list when no files/ paths are
+  found ([#114](https://github.com/mathause/filefinder/pull/114))
 
 - Changes to `FileContainer`:
 

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -130,15 +130,13 @@ class _Finder(_FinderBase):
 
             all_patterns.append(full_pattern)
 
-        if all_paths:
-            df = self._parse_paths(all_paths, on_parse_error=on_parse_error)
-        elif _allow_empty:
-            return []
-        else:
+        if len(all_paths) == 0 and not _allow_empty:
             msg = "Found no files matching criteria. Tried the following pattern(s):"
             msg += "".join(f"\n- '{pattern}'" for pattern in all_patterns)
             raise ValueError(msg)
 
+        # NOTE: also creates the correct (empty) df if no paths are found
+        df = self._parse_paths(all_paths, on_parse_error=on_parse_error)
         fc = FileContainer(df)
 
         len_all = len(fc.df)

--- a/filefinder/tests/__init__.py
+++ b/filefinder/tests/__init__.py
@@ -14,7 +14,7 @@ def assert_no_warnings():
         assert len(record) == 0, "got unexpected warning(s)"
 
 
-def assert_empty_filecontainer(fc, columns=None):
+def assert_filecontainer_empty(fc, columns=None):
 
     assert isinstance(fc, FileContainer)
 

--- a/filefinder/tests/__init__.py
+++ b/filefinder/tests/__init__.py
@@ -1,6 +1,10 @@
 import warnings
 from contextlib import contextmanager
 
+import pandas as pd
+
+from filefinder import FileContainer
+
 
 @contextmanager
 def assert_no_warnings():
@@ -8,3 +12,15 @@ def assert_no_warnings():
     with warnings.catch_warnings(record=True) as record:
         yield record
         assert len(record) == 0, "got unexpected warning(s)"
+
+
+def assert_empty_filecontainer(fc, columns=None):
+
+    assert isinstance(fc, FileContainer)
+
+    assert isinstance(fc.df, pd.DataFrame)
+    assert fc.df.index.name == "path"
+    assert len(fc) == 0, f"FileContainer not empty ({len(fc)=})"
+
+    if columns:
+        assert set(fc.df.columns) == set(columns)

--- a/filefinder/tests/__init__.py
+++ b/filefinder/tests/__init__.py
@@ -1,5 +1,6 @@
 import warnings
 from contextlib import contextmanager
+from typing import Iterable
 
 import pandas as pd
 
@@ -14,7 +15,18 @@ def assert_no_warnings():
         assert len(record) == 0, "got unexpected warning(s)"
 
 
-def assert_filecontainer_empty(fc, columns=None):
+def assert_filecontainer_empty(
+    fc: FileContainer, columns: str | Iterable[str] | None = None
+):
+    """checks passed object is an empty `FileContainer`
+
+    Parameters
+    ----------
+    fc : FileContainer
+        Filecontainer to ensure is empty.
+    columns : str, iterable of str | None, optional
+        Keys/ columns the empty FileContainer should have.
+    """
 
     assert isinstance(fc, FileContainer)
 
@@ -25,5 +37,6 @@ def assert_filecontainer_empty(fc, columns=None):
     if isinstance(columns, str):
         columns = {columns}
 
+    # DataFrame should contain the keys as empty columns
     if columns:
         assert set(fc.df.columns) == set(columns)

--- a/filefinder/tests/__init__.py
+++ b/filefinder/tests/__init__.py
@@ -22,5 +22,8 @@ def assert_filecontainer_empty(fc, columns=None):
     assert fc.df.index.name == "path"
     assert len(fc) == 0, f"FileContainer not empty ({len(fc)=})"
 
+    if isinstance(columns, str):
+        columns = {columns}
+
     if columns:
         assert set(fc.df.columns) == set(columns)

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -6,6 +6,8 @@ import pytest
 
 from filefinder import FileFinder
 
+from . import assert_empty_filecontainer
+
 
 @pytest.fixture(scope="module")
 def tmp_path(tmp_path_factory):
@@ -212,10 +214,10 @@ def test_find_path_none_found(tmp_path, test_paths):
         ff.find_paths({"a": "foo"})
 
     result = ff.find_paths(a="foo", _allow_empty=True)
-    assert result == []
+    assert_empty_filecontainer(result, columns=("a"))
 
     result = ff.find_paths({"a": "foo"}, _allow_empty=True)
-    assert result == []
+    assert_empty_filecontainer(result, columns=("a"))
 
 
 def test_find_paths_simple(tmp_path, test_paths):
@@ -370,13 +372,13 @@ def test_find_file_none_found(tmp_path, test_paths):
         ff.find_files({"a": "XXX"})
 
     result = ff.find_files(a="XXX", _allow_empty=True)
-    assert result == []
+    assert_empty_filecontainer(result, columns=("a", "file_pattern"))
 
     result = ff.find_files({"a": "XXX"}, _allow_empty=True)
-    assert result == []
+    assert_empty_filecontainer(result, columns=("a", "file_pattern"))
 
     result = ff.find_files({"a": "XXX"}, _allow_empty=True, a="XXX")
-    assert result == []
+    assert_empty_filecontainer(result, columns=("a", "file_pattern"))
 
 
 def test_find_file_simple(tmp_path, test_paths):

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -214,10 +214,10 @@ def test_find_path_none_found(tmp_path, test_paths):
         ff.find_paths({"a": "foo"})
 
     result = ff.find_paths(a="foo", _allow_empty=True)
-    assert_filecontainer_empty(result, columns=("a"))
+    assert_filecontainer_empty(result, columns="a")
 
     result = ff.find_paths({"a": "foo"}, _allow_empty=True)
-    assert_filecontainer_empty(result, columns=("a"))
+    assert_filecontainer_empty(result, columns="a")
 
 
 def test_find_paths_simple(tmp_path, test_paths):

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -6,7 +6,7 @@ import pytest
 
 from filefinder import FileFinder
 
-from . import assert_empty_filecontainer
+from . import assert_filecontainer_empty
 
 
 @pytest.fixture(scope="module")
@@ -214,10 +214,10 @@ def test_find_path_none_found(tmp_path, test_paths):
         ff.find_paths({"a": "foo"})
 
     result = ff.find_paths(a="foo", _allow_empty=True)
-    assert_empty_filecontainer(result, columns=("a"))
+    assert_filecontainer_empty(result, columns=("a"))
 
     result = ff.find_paths({"a": "foo"}, _allow_empty=True)
-    assert_empty_filecontainer(result, columns=("a"))
+    assert_filecontainer_empty(result, columns=("a"))
 
 
 def test_find_paths_simple(tmp_path, test_paths):
@@ -372,13 +372,13 @@ def test_find_file_none_found(tmp_path, test_paths):
         ff.find_files({"a": "XXX"})
 
     result = ff.find_files(a="XXX", _allow_empty=True)
-    assert_empty_filecontainer(result, columns=("a", "file_pattern"))
+    assert_filecontainer_empty(result, columns=("a", "file_pattern"))
 
     result = ff.find_files({"a": "XXX"}, _allow_empty=True)
-    assert_empty_filecontainer(result, columns=("a", "file_pattern"))
+    assert_filecontainer_empty(result, columns=("a", "file_pattern"))
 
     result = ff.find_files({"a": "XXX"}, _allow_empty=True, a="XXX")
-    assert_empty_filecontainer(result, columns=("a", "file_pattern"))
+    assert_filecontainer_empty(result, columns=("a", "file_pattern"))
 
 
 def test_find_file_simple(tmp_path, test_paths):


### PR DESCRIPTION

- [x] closes #18

If no files are found returns an empty `FileContainer` instead of a list. Tests for the empty `FileContainer` were already added in #113.