### PR TITLE
deprecate and avoid `combine_by_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
   - Renamed the `"filename"` column to `"path"` and made it a `pd.Index`, thus removing
     this column from the underlying `DataFrame` ([#113](https://github.com/mathause/filefinder/pull/113)).
+  - Deprecated `combine_by_key` ([#115](https://github.com/mathause/filefinder/pull/115)).
 
 - Explicitly test on python 3.13 ([#103](https://github.com/mathause/filefinder/pull/103)).
 - Drop support for python 3.9 ([#102](https://github.com/mathause/filefinder/pull/102)).

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -36,11 +36,8 @@ def _assert_unique(df):
     duplicates = df.duplicated()
 
     if duplicates.any():
-        duplicated = df[duplicates]
-        msg = (
-            "This query leads to non-unique metadata. Please adjust your query.\n"
-            f"First five duplicates:\n{duplicated.head()}"
-        )
+        duplicated = df[duplicates].head()
+        msg = f"Non-unique metadata detected.\nFirst five duplicates:\n{duplicated}"
 
         raise ValueError(msg)
 

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -31,6 +31,20 @@ def _assert_valid_keys(keys):
             raise ValueError(f"'{key}' is not a valid placeholder")
 
 
+def _assert_unique(df):
+
+    duplicates = df.duplicated()
+
+    if duplicates.any():
+        duplicated = df[duplicates]
+        msg = (
+            "This query leads to non-unique metadata. Please adjust your query.\n"
+            f"First five duplicates:\n{duplicated.head()}"
+        )
+
+        raise ValueError(msg)
+
+
 class _FinderBase:
     def __init__(self, pattern, suffix=""):
 
@@ -137,18 +151,9 @@ class _Finder(_FinderBase):
 
         # NOTE: also creates the correct (empty) df if no paths are found
         df = self._parse_paths(all_paths, on_parse_error=on_parse_error)
-        fc = FileContainer(df)
+        _assert_unique(df)
 
-        len_all = len(fc.df)
-        len_unique = len(fc.combine_by_key().unique())
-
-        if len_all != len_unique:
-            duplicated = fc.df[fc.df.duplicated()]
-            msg = f"This query leads to non-unique metadata. Please adjust your query.\nFirst five duplicates:\n{duplicated.head()}"
-
-            raise ValueError(msg)
-
-        return fc
+        return FileContainer(df)
 
     def find_single(self, keys=None, **keys_kwargs):
         """
@@ -571,6 +576,14 @@ class FileContainer:
             return ret
 
     def combine_by_key(self, keys=None, sep="."):
+        warnings.warn(
+            "`combine_by_key` has been deprecated and will be removed in a future version",
+            FutureWarning,
+        )
+
+        return self._combine_by_keys(keys=keys, sep=sep)
+
+    def _combine_by_keys(self, keys=None, sep="."):
         """combine columns"""
 
         if keys is None:

--- a/filefinder/cmip.py
+++ b/filefinder/cmip.py
@@ -38,14 +38,15 @@ def create_ensnumber(filelist, keys=None):
     if keys is None:
         keys = ("exp", "table", "varn", "model")
 
+    keys = list(keys)
     df = filelist.df
-    combined = filelist.combine_by_key(keys)
+    multiindex = pd.MultiIndex.from_frame(df[keys])
 
     df["ensnumber"] = -1
 
-    for comb in combined.unique():
+    for idx in multiindex.unique():
 
-        sel = combined == comb
+        sel = multiindex == idx
         numbers = list(range(sel.sum()))
         df.loc[sel, "ensnumber"] = numbers
 

--- a/filefinder/tests/test_filecontainer.py
+++ b/filefinder/tests/test_filecontainer.py
@@ -80,24 +80,30 @@ def test_filecontainer_search(example_df, example_fc):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
+def test_fc_combine_by_key_deprecated(example_fc):
+
+    with pytest.warns(FutureWarning, match="`combine_by_key` has been deprecated"):
+        example_fc[[0]].combine_by_key()
+
+
 def test_fc_combine_by_keys(example_fc):
 
-    result = example_fc[[0]].combine_by_key()
+    result = example_fc[[0]]._combine_by_keys()
 
     # create one manually
     expected = pd.Series(["a.d.r"], index=pd.Index(["file0"], name="path"))
     pd.testing.assert_series_equal(result, expected)
 
-    result = example_fc.combine_by_key()
+    result = example_fc._combine_by_keys()
     expected = map(".".join, example_fc.df.values)
     expected = pd.Series(expected, index=example_fc.df.index)
 
     # different sep
-    result = example_fc.combine_by_key(sep="|")
+    result = example_fc._combine_by_keys(sep="|")
     expected = map("|".join, example_fc.df.values)
     expected = pd.Series(expected, index=example_fc.df.index)
 
     # not all columns
-    result = example_fc.combine_by_key(keys=("model", "res"))
+    result = example_fc._combine_by_keys(keys=("model", "res"))
     expected = map(".".join, example_fc.df[["model", "res"]].values)
     expected = pd.Series(expected, index=example_fc.df.index)

--- a/filefinder/tests/test_filefinder.py
+++ b/filefinder/tests/test_filefinder.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from filefinder import FileFinder
+from filefinder._filefinder import _assert_unique
 
 from . import assert_filecontainer_empty
 
@@ -65,6 +66,17 @@ def test_only_named_fields(pattern):
 
     with pytest.raises(ValueError, match="Only named fields are currently allowed"):
         FileFinder(pattern, "")
+
+
+def test_assert_unique():
+
+    # no error raised
+    df = pd.DataFrame.from_records([("a", "d"), ("a", "h")], columns=("model", "res"))
+    _assert_unique(df)
+
+    df = pd.DataFrame.from_records([("a", "d"), ("a", "d")], columns=("model", "res"))
+    with pytest.raises(ValueError, match="Non-unique metadata detected"):
+        _assert_unique(df)
 
 
 def test_pattern_property():
@@ -218,6 +230,16 @@ def test_find_path_none_found(tmp_path, test_paths):
 
     result = ff.find_paths({"a": "foo"}, _allow_empty=True)
     assert_filecontainer_empty(result, columns="a")
+
+
+def test_find_paths_non_unique():
+
+    # test raises error for non-unique metadata - AFAIK not possible for real paths
+
+    ff = FileFinder("{cat}", "", test_paths=["a/", "a/"])
+
+    with pytest.raises(ValueError, match="Non-unique metadata detected"):
+        ff.find_paths()
 
 
 def test_find_paths_simple(tmp_path, test_paths):
@@ -379,6 +401,16 @@ def test_find_file_none_found(tmp_path, test_paths):
 
     result = ff.find_files({"a": "XXX"}, _allow_empty=True, a="XXX")
     assert_filecontainer_empty(result, columns=("a", "file_pattern"))
+
+
+def test_find_files_non_unique():
+
+    # test raises error for non-unique metadata - AFAIK not possible for real paths
+
+    ff = FileFinder("", "{cat}", test_paths=["/a", "/a"])
+
+    with pytest.raises(ValueError, match="Non-unique metadata detected"):
+        ff.find_files()
 
 
 def test_find_file_simple(tmp_path, test_paths):


### PR DESCRIPTION

- towards #111 point 6.

Deprecate and avoid `combine_by_key`. I used it because we cannot call `unique` on a `DataFrame` to get unique rows over several columns. However, we can also do this with a `pd.MultiIndex` or we use `df.duplicated()`. 