### PR TITLE
`FileContainer`: add path and meta properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
   - Renamed the `"filename"` column to `"path"` and made it a `pd.Index`, thus removing
     this column from the underlying `DataFrame` ([#113](https://github.com/mathause/filefinder/pull/113)).
+  - Added `meta` and `paths` properties to `FileContainer` which allow to iterate over them
+    ([#121](https://github.com/mathause/filefinder/pull/121)).
   - Deprecated `combine_by_key` ([#115](https://github.com/mathause/filefinder/pull/115)).
   - Added the number of paths to the repr ([#116](https://github.com/mathause/filefinder/pull/116)).
 

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import warnings
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -608,7 +609,7 @@ class FileContainer:
             return ret
 
     @property
-    def meta(self) -> list[dict]:
+    def meta(self) -> list[dict[str, Any]]:
         return self.df.to_dict("records")
 
     @property

--- a/filefinder/_filefinder.py
+++ b/filefinder/_filefinder.py
@@ -579,6 +579,14 @@ class FileContainer:
             ret.df = self.df.iloc[key]
             return ret
 
+    @property
+    def meta(self) -> list[dict]:
+        return self.df.to_dict("records")
+
+    @property
+    def paths(self) -> list[str]:
+        return self.df.index.to_list()
+
     def combine_by_key(self, keys=None, sep="."):
         warnings.warn(
             "`combine_by_key` has been deprecated and will be removed in a future version",

--- a/filefinder/tests/test_filecontainer.py
+++ b/filefinder/tests/test_filecontainer.py
@@ -80,6 +80,35 @@ def test_fc_getitem(example_df, example_fc):
     assert_filecontainer_empty(result, columns=["model", "scen", "res"])
 
 
+def test_filecontainer_paths(example_fc):
+
+    result = example_fc.paths
+    expected = [
+        "file0",
+        "file1",
+        "file2",
+        "file3",
+        "file4",
+    ]
+
+    assert result == expected
+
+
+def test_filecontainer_meta(example_fc):
+
+    result = example_fc.meta
+
+    expected = [
+        {"model": "a", "scen": "d", "res": "r"},
+        {"model": "a", "scen": "h", "res": "r"},
+        {"model": "b", "scen": "h", "res": "r"},
+        {"model": "b", "scen": "d", "res": "r"},
+        {"model": "c", "scen": "d", "res": "r"},
+    ]
+
+    assert result == expected
+
+
 def test_filecontainer_search(example_df, example_fc):
 
     with pytest.raises(KeyError):


### PR DESCRIPTION
- towards #108

Once again I am not sure about the names. Should it be `paths` and `meta` __or__ `path` and `meta`, __or__ `paths` and `metas`? Or ...?