### PR TITLE
define and test minimum dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   test:
-    name: py${{ matrix.python-version }}
+    name: py${{ matrix.python-version }} ${{ matrix.env }}
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,23 +20,41 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12", "3.13"]
         os: [ "ubuntu-latest"]
+        env: [""]
+        include:
+          - env: "min_all_deps"
+            os: "ubuntu-latest"
+            python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Set environment variables
+      run: |
+        if [[ "${{ matrix.env }}" == "" ]]; then
+          echo "PIP_ENV_FILE=environment.txt" >> $GITHUB_ENV
+        else
+          echo "PIP_ENV_FILE=${{ matrix.env }}.txt" >> $GITHUB_ENV
+        fi
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest pytest-cov
+        python -m pip install -r "ci/requirements/${{ env.PIP_ENV_FILE }}"
         python -m pip install -e .
+
     - name: Test with pytest
       run: python -m pytest
         --cov=filefinder
         --cov-report=xml
         --junitxml=test-results/${{ runner.os }}-${{ matrix.python-version }}.xml
+
     - name: Upload code coverage to Codecov
       uses: codecov/codecov-action@v4
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Fetch all history for all branches and tags.
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -48,6 +50,10 @@ jobs:
         python -m pip install pytest pytest-cov
         python -m pip install -r "ci/requirements/${{ env.PIP_ENV_FILE }}"
         python -m pip install -e .
+
+    - name: List dependencies
+      run: |
+        python -m pip list
 
     - name: Test with pytest
       run: python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 - An empty `FileContainer` is returned instead of an empty list when no files/ paths are
   found ([#114](https://github.com/mathause/filefinder/pull/114))
 
+- Define and test the minimum supported versions of the dependencies ([#125](https://github.com/mathause/filefinder/pull/125)).
+
+  | Package    | Old     | New    |
+  | ---------- | ------- | ------ |
+  | numpy      | undefined | 1.24 |
+  | pandas     | undefined |  2.0 |
+  | parse      | undefined | 1.19 |
+
 - Changes to `FileContainer`:
 
   - Renamed the `"filename"` column to `"path"` and made it a `pd.Index`, thus removing

--- a/ci/requirements/environment.txt
+++ b/ci/requirements/environment.txt
@@ -1,0 +1,3 @@
+numpy
+pandas
+parse

--- a/ci/requirements/min_all_deps.txt
+++ b/ci/requirements/min_all_deps.txt
@@ -1,3 +1,3 @@
-numpy=1.24
-pandas=2.0
-parse=1.19
+numpy==1.24
+pandas==2.0
+parse==1.19

--- a/ci/requirements/min_all_deps.txt
+++ b/ci/requirements/min_all_deps.txt
@@ -1,0 +1,3 @@
+numpy=1.24
+pandas=2.0
+parse=1.19

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,9 @@ packages = find:
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 python_requires = >=3.10
 install_requires =
-    pandas
-    parse
+    numpy >=1.24
+    pandas >=2.0
+    parse >=1.19
 
 [flake8]
 ignore=


### PR DESCRIPTION

- closes #124

Defines the minimum dependencies as per the xarray interpretation of NEP29 and adds a test environment for them. Done using pip now. What is not included here is a min-deps check. Need to manually check but I think that's ok.

Let's see if that works.